### PR TITLE
Changed logic in AutoCreateRedirectOnMove

### DIFF
--- a/source/Handlers/AutoCreateRedirectOnMove.cs
+++ b/source/Handlers/AutoCreateRedirectOnMove.cs
@@ -34,7 +34,7 @@ namespace SharedSource.RedirectModule.Handlers
         private void CreateRedirectItem(Item item, Item oldParent)
         {
             // we only want a redirect on pages and media assets
-            if (oldParent.Paths.IsContentItem || oldParent.Paths.IsMediaItem)
+            if ((oldParent.Paths.IsContentItem || oldParent.Paths.IsMediaItem) && item.Parent.Paths.ContentPath != oldParent.Paths.ContentPath)
             {    
                 string oldPath = LinkManager.GetItemUrl(oldParent).Replace("/sitecore/shell", "") + "/" + LinkManager.GetItemUrl(item).Split('/').Last();
                 Database db = Sitecore.Configuration.Factory.GetDatabase("master");


### PR DESCRIPTION
We experienced a bug where if we moved an item to a new spot where the path would stay the same. The redirect module would make a redirect to the item itself. This of course caused an infinite loop of redirects.

Therefore I Changed the logic in AutoCreateRedirectOnMove so it doesn't create redirets on items that doesn't move to a new path.